### PR TITLE
Fixed collisions

### DIFF
--- a/models/gazebo/worlds/BP-setup.world
+++ b/models/gazebo/worlds/BP-setup.world
@@ -24,8 +24,8 @@
     <model name="table">
      <include>
       <uri>model://BP_table</uri>
-      <pose>0.1 -0.5985 0.848 1.57 0 0</pose>
      </include>
+     <pose>0.1 -0.5985 0.848 1.57 0 0</pose>
      <joint name="fixed to ground" type="fixed">
        <parent>world</parent>
        <child>BP_table::base_link</child>
@@ -37,8 +37,8 @@
    <model name="cube">
     <include>
       <uri>model://BP_cube</uri>
-      <pose>0.35 -0.038964 0.967105 0 0 0</pose>
     </include> 
+    <pose>0.35 -0.038964 0.967105 0 0 0</pose>
    </model>
 
     <!-- Camera -->


### PR DESCRIPTION
The problem was that when `model name` is specified in the `sdf` (which is necessary when adding a new joint to the model and we added the fixed one), the `pose` has to be specified out of the `include` and within `model`.
The `pose` was not loaded correctly and all the models were loaded at the origin, causing the collisions.

I've tried on gitpod and it works:

![collisions](https://user-images.githubusercontent.com/9716288/88684280-fa68ef00-d0f4-11ea-999b-34aeaa4a5ab1.gif)

@Nicogene could you please try on your system?